### PR TITLE
Fix test_shutils when there is “python3” but no “python”

### DIFF
--- a/tests/test_shutils.py
+++ b/tests/test_shutils.py
@@ -82,8 +82,9 @@ def test_shutils():
     assert all('PATH' in key for key in pathdict)
 
    #print('testing which...')
-    assert which('python').endswith(('python','python.exe'))
-    assert which('python') in which('python',all=True)
+    python = 'python' if which('python') else 'python3'
+    assert which(python).endswith((python,'python.exe'))
+    assert which(python) in which(python,all=True)
 
    #print('testing find...')
    #print(find('python','/usr/local',type='l'))


### PR DESCRIPTION
~~This allows the tests to pass in environments where the Python interpreter has some other name, such as “`python3`”.~~

This allows the tests to pass in environments where there is a “`python3`” but no “`python`” in the executable search path.