### PR TITLE
update sphinx to 6.2.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,19 +1,40 @@
 # Packages required to build docs
 # dependencies pinned as:
-# https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
+# https://github.com/readthedocs/readthedocs.org/blob/4dd655eaa5a36aa2cb9eed3e98961419536f99e8/requirements/docs.txt
 
-alabaster==0.7.12
-babel==2.9.1
-docutils==0.16
-imagesize==1.3.0
-importlib-metadata==4.11.3
+alabaster==0.7.13
+babel==2.12.1
+certifi==2023.7.22
+charset-normalizer==3.2.0
+click==8.1.6
+colorama==0.4.6
+docutils==0.18.1
+idna==3.4
+imagesize==1.4.1
 jinja2==3.1.3
-markupsafe==2.1.1
-packaging==21.3
-pygments==2.15.0
-pyparsing==3.0.8
-readthedocs-sphinx-search==0.1.1
+livereload==2.6.3
+markdown-it-py==3.0.0
+markupsafe==2.1.3
+mdit-py-plugins==0.4.0
+mdurl==0.1.2
+myst-parser==2.0.0
+packaging==23.1
+pygments==2.16.1
+pyyaml==6.0.1
+readthedocs-sphinx-search==0.3.1
 requests==2.31.0
-sphinx==4.5.0
-sphinx-notfound-page==0.8
-sphinx-rtd-theme==1.0.0
+six==1.16.0
+snowballstemmer==2.2.0
+sphinx==6.2.1
+sphinx-autobuild==2021.3.14
+sphinx-copybutton==0.5.2
+sphinx-design==0.5.0
+sphinx-hoverxref==1.3.0
+sphinx-intl==2.1.0
+sphinx-multiproject==1.0.0rc1
+sphinx-notfound-page==0.8.3
+sphinx-prompt==1.6.0
+sphinx-rtd-theme==1.2.2
+sphinx-tabs==3.4.1
+tornado==6.3.3
+urllib3==2.0.4


### PR DESCRIPTION
## Summary
update sphinx to 6.2.1, still builds with python 3.8
