### PR TITLE
Fix bare except clauses in shutils.py, __main__.py, and utils.py

### DIFF
--- a/pox/__main__.py
+++ b/pox/__main__.py
@@ -32,7 +32,7 @@ def help(function=None):
         if isfunction(function):
             print(function.__doc__)
             return
-    except:
+    except Exception:
         pass
     print("Please provide a 'pox' command enclosed in quotes.\n")
     print("For example:")
@@ -46,11 +46,11 @@ if __name__=='__main__':
     import sys
     try:
         func = sys.argv[1]
-    except: func = None
+    except IndexError: func = None
     if func:
         try:
             exec('print(%s)' % func)
-        except:
+        except Exception:
             print("Error: incorrect syntax '%s'\n" % func)
             exec('print(%s.__doc__)' % func.split('(')[0])
     else: help()

--- a/pox/shutils.py
+++ b/pox/shutils.py
@@ -46,7 +46,7 @@ def homedir():
         homedir = env('USERPROFILE',all=False) or os.path.expandvars('$HOME')
         if '$' in homedir: raise ValueError
         return homedir
-    except:
+    except Exception:
         homedir = None
         directory = os.curdir
         while not homedir:
@@ -76,7 +76,7 @@ def username():
     '''
     try:
         return os.getlogin()
-    except:
+    except Exception:
         uname = os.path.expandvars('$USER')
         if '$' in uname: uname = env('USERNAME', all=False)
         return uname
@@ -299,7 +299,7 @@ def find(patterns,root=None,recurse=True,type=None,verbose=False):
                 if errind[0] not in path:
                     path = path.strip()
                     pathlist.append(os.path.abspath(path))
-    except:
+    except Exception:
         folders = False;files = False;links = False
         if type in ['f']: files = True
         elif type in ['l']: links = True

--- a/pox/utils.py
+++ b/pox/utils.py
@@ -165,7 +165,7 @@ def convert(files,platform=None,pathsep=None,verbose=True):
             outfile.write(filestring)
             outfile.close()
             if verbose: print("Converted '%s' to '%s' format" % (file,platform))
-        except:
+        except Exception:
             if verbose: print("File conversion failed for '%s'" % (file))
             allconverted = 1 # Error 1: file conversion failed
     return allconverted


### PR DESCRIPTION
Fix bare `except:` clauses that catch `BaseException` (including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`), replacing them with `except Exception:` or more specific exception types.

**Changes:**

`pox/shutils.py` (lines 49, 79, 302):
- `get_home()`: `except:` → `except Exception:`
- `get_username()`: `except:` → `except Exception:`
- Path traversal loop: `except:` → `except Exception:`

`pox/__main__.py` (lines 35, 49, 53):
- Main try block: `except:` → `except Exception:`
- `sys.argv` access: `except:` → `except IndexError:` (more specific — only `IndexError` is possible here)
- `exec()` call: `except:` → `except Exception:`

`pox/utils.py` (line 168):
- File conversion: `except:` → `except Exception:`

Bare `except:` clauses are considered bad practice (PEP 8 / flake8 E722) because they silently swallow signals like `KeyboardInterrupt`, making programs impossible to interrupt with Ctrl+C.